### PR TITLE
Remove file.sync which is not mandatory and slow down a lot the install

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -144,11 +144,6 @@ func WriteFile(from io.Reader, to string, permissions os.FileMode) error {
 		return fmt.Errorf("failed to write to file '%s': %w", to, err)
 	}
 
-	err = file.Sync()
-	if err != nil {
-		return fmt.Errorf("failed to sync file contents to disk: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
When we write data to target file from buffer using file.ReadFrom, we issue just after file.Sync to make sure that data are written even if program exit anormaly after.
This extra caution is not really required here, and it delay a lot the installation in some case.

Here the delay installing gcloud with sync activated:
```
$ time ./dist/backplane-tools_linux_amd64_v1/backplane-tools install gcloud
Installing the following tools:
- gcloud google-cloud-cli-469.0.0-linux-x86_64

Installing gcloud
Successfully installed gcloud

real    0m14.211s
user    0m5.657s
sys     0m2.563s
```
And here the delay without sync:
```
$ time backplane-tools install gcloud
Installing the following tools:
- gcloud google-cloud-cli-469.0.0-linux-x86_64

Installing gcloud
Successfully installed gcloud

real    3m29.527s
user    0m7.626s
sys     0m9.223s
```